### PR TITLE
Minor fixes hardcoded maxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ ISIC/
      
      ISBI2016_ISIC_Part3B_Training_GroundTruth.csv
     
-2. For training, run: ``python scripts/segmentation_train.py --data_dir input data direction --out_dir output data direction --image_size 256 --num_channels 128 --class_cond False --num_res_blocks 2 --num_heads 1 --learn_sigma True --use_scale_shift_norm False --attention_resolutions 16 --diffusion_steps 1000 --noise_schedule linear --rescale_learned_sigmas False --rescale_timesteps False --lr 1e-4 --batch_size 8``
+2. For training, run: ``python scripts/segmentation_train.py --data_name ISIC --data_dir input data direction --out_dir output data direction --image_size 256 --num_channels 128 --class_cond False --num_res_blocks 2 --num_heads 1 --learn_sigma True --use_scale_shift_norm False --attention_resolutions 16 --diffusion_steps 1000 --noise_schedule linear --rescale_learned_sigmas False --rescale_timesteps False --lr 1e-4 --batch_size 8``
     
-3. For sampling, run: ``python scripts/segmentation_sample.py --data_dir input data direction --out_dir output data direction --model_path saved model --image_size 256 --num_channels 128 --class_cond False --num_res_blocks 2 --num_heads 1 --learn_sigma True --use_scale_shift_norm False --attention_resolutions 16 --diffusion_steps 1000 --noise_schedule linear --rescale_learned_sigmas False --rescale_timesteps False --num_ensemble 5``
+3. For sampling, run: ``python scripts/segmentation_sample.py --data_name ISIC --data_dir input data direction --out_dir output data direction --model_path saved model --image_size 256 --num_channels 128 --class_cond False --num_res_blocks 2 --num_heads 1 --learn_sigma True --use_scale_shift_norm False --attention_resolutions 16 --diffusion_steps 1000 --noise_schedule linear --rescale_learned_sigmas False --rescale_timesteps False --num_ensemble 5``
 
 
 In default, the samples will be saved at `` ./results/`` 

--- a/scripts/segmentation_train.py
+++ b/scripts/segmentation_train.py
@@ -55,7 +55,7 @@ def main():
         model.to(device = th.device('cuda', int(args.gpu_dev)))
     else:
         model.to(dist_util.dev())
-    schedule_sampler = create_named_schedule_sampler(args.schedule_sampler, diffusion,  maxt=1000)
+    schedule_sampler = create_named_schedule_sampler(args.schedule_sampler, diffusion,  maxt=args.diffusion_steps)
 
 
     logger.log("training...")


### PR DESCRIPTION
1. maxt was hardcoded to 1000. led to crash when args.diffusion_steps was not 1000.
2. The readme command to run training on ISIC had --data_name ISIC missing.